### PR TITLE
fix: add extensions to the `test` option of React plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"@playwright/test": "^1.54.1",
 		"@rsbuild/core": "^1.4.12",
 		"@rsbuild/plugin-preact": "^1.5.1",
-		"@rsbuild/plugin-react": "^1.3.4",
+		"@rsbuild/plugin-react": "^1.4.0",
 		"@rsbuild/plugin-svgr": "^1.2.1",
 		"@rsbuild/plugin-vue": "^1.1.0",
 		"@rslib/core": "^0.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         specifier: ^1.5.1
         version: 1.5.1(@rsbuild/core@1.4.12)(preact@10.27.0)
       '@rsbuild/plugin-react':
-        specifier: ^1.3.4
-        version: 1.3.4(@rsbuild/core@1.4.12)
+        specifier: ^1.4.0
+        version: 1.4.0(@rsbuild/core@1.4.12)
       '@rsbuild/plugin-svgr':
         specifier: ^1.2.1
         version: 1.2.1(@rsbuild/core@1.4.12)(typescript@5.9.2)
@@ -362,8 +362,8 @@ packages:
     peerDependencies:
       '@rsbuild/core': 1.x
 
-  '@rsbuild/plugin-react@1.3.4':
-    resolution: {integrity: sha512-PeLmPkUUm+t2cBGBe1WHhw1NNPHDFnKiXnRUGM5WSSlSZWfSi96RbeLqrm+gH6TaefdyvmLvurJu+7tSSUrQjQ==}
+  '@rsbuild/plugin-react@1.4.0':
+    resolution: {integrity: sha512-YhhOUOonJBjnKpUf7E4iXKidldPWAGmYBRtDjQgcSmW4tbW0DasFpNCqLn5870Q2Ly6oCU06sLv+8G597I36+w==}
     peerDependencies:
       '@rsbuild/core': 1.x
 
@@ -461,8 +461,8 @@ packages:
       '@prefresh/core': ^1.5.0
       '@prefresh/utils': ^1.2.0
 
-  '@rspack/plugin-react-refresh@1.4.3':
-    resolution: {integrity: sha512-wZx4vWgy5oMEvgyNGd/oUKcdnKaccYWHCRkOqTdAPJC3WcytxhTX+Kady8ERurSBiLyQpoMiU3Iyd+F1Y2Arbw==}
+  '@rspack/plugin-react-refresh@1.5.0':
+    resolution: {integrity: sha512-pYOmc1mrK8Ui/7VWUgjKt9YqrxFn4woURTgGpFYWwsFvJxmWm05zog4fUbChvErbaBHkx1aA+KHxIvM/6tFODg==}
     peerDependencies:
       react-refresh: '>=0.10.0 <1.0.0'
       webpack-hot-middleware: 2.x
@@ -1930,10 +1930,10 @@ snapshots:
     transitivePeerDependencies:
       - preact
 
-  '@rsbuild/plugin-react@1.3.4(@rsbuild/core@1.4.12)':
+  '@rsbuild/plugin-react@1.4.0(@rsbuild/core@1.4.12)':
     dependencies:
       '@rsbuild/core': 1.4.12
-      '@rspack/plugin-react-refresh': 1.4.3(react-refresh@0.17.0)
+      '@rspack/plugin-react-refresh': 1.5.0(react-refresh@0.17.0)
       react-refresh: 0.17.0
     transitivePeerDependencies:
       - webpack-hot-middleware
@@ -1941,7 +1941,7 @@ snapshots:
   '@rsbuild/plugin-svgr@1.2.1(@rsbuild/core@1.4.12)(typescript@5.9.2)':
     dependencies:
       '@rsbuild/core': 1.4.12
-      '@rsbuild/plugin-react': 1.3.4(@rsbuild/core@1.4.12)
+      '@rsbuild/plugin-react': 1.4.0(@rsbuild/core@1.4.12)
       '@svgr/core': 8.1.0(typescript@5.9.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))
       '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))(typescript@5.9.2)
@@ -2033,7 +2033,7 @@ snapshots:
       '@prefresh/core': 1.5.5(preact@10.27.0)
       '@prefresh/utils': 1.2.1
 
-  '@rspack/plugin-react-refresh@1.4.3(react-refresh@0.17.0)':
+  '@rspack/plugin-react-refresh@1.5.0(react-refresh@0.17.0)':
     dependencies:
       error-stack-parser: 2.1.4
       html-entities: 2.6.0

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,14 @@ export const pluginMdx = (options: PluginMdxOptions = {}): RsbuildPlugin => ({
 			if (chain.plugins.has(REACT_FAST_REFRESH)) {
 				chain.plugins.get(REACT_FAST_REFRESH).tap((options) => {
 					const firstOption = options[0] ?? {};
+					if (firstOption.test) {
+						firstOption.test = [
+							...(Array.isArray(firstOption.test)
+								? firstOption.test
+								: [firstOption.test]),
+							MDX_REGEXP,
+						];
+					}
 					firstOption.include = [...(firstOption.include || []), MDX_REGEXP];
 					options[0] = firstOption;
 					return options;


### PR DESCRIPTION
- Update @rsbuild/plugin-react to v1.4.0
- Add extensions to the `test` option of React plugin, related: https://github.com/web-infra-dev/rsbuild/pull/5969